### PR TITLE
Add scripts to ease setting of variables and publishing docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ override.tf.json
 terraform.rc
 
 # Ignore the terraform/service prority calc
-terraform/service/highest_priority.txt
+terraform/dashboard/highest_priority.txt
+terraform/dashboard/highest_alb_listener_priority.txt
 
 .env
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A Streamlit dashboard to display information from the Github Copilot Usage API endpoints.
 
 ## Disclaimer
+
 ### Early Stage & Accessibility Disclaimer
 
 Please note that the code available in this repository for creating a Dashboard to track GitHub Copilot usage within your organisation is in its **early stages of development**. It may **not** fully comply with all Civil Service / ONS best practices for software development. Currently, it is being used by a **limited number of individuals** within ONS. Additionally, due to the limited number of users, this project has **not** been tested for WACG 2.1 compliance nor accessibility. Please consider this when using the project.
@@ -48,6 +49,7 @@ export APP_URL=http://localhost:8501
 ```
 
 **Please Note:**
+
 - APP_URL should point to the url which the app is running at. For example, if running locally you'd use localhost:8501 and on AWS the appropriate domain url.
 - The GITHUB_APP_CLIENT_ID and GITHUB_APP_CLIENT_SECRET can be found from the GitHub App in developer settings.
 
@@ -141,6 +143,48 @@ These credentials should also allow access to S3 for historic reporting.
 
 When you make changes to the application a new container image must be pushed to ECR.
 
+### Scripted Push to ECR
+
+This script assumes you have a ~/.aws/credentials file set up with profiles of the credentials for pushing to ECR and that a suitably named repository (environmentname-toolname) is already created in the ECR.  In the credential file you should use the profile that matches the IAM user associated with permissions to push to the ECR.
+
+Setup the environment for the correct credentials. Ensure the script is executable:
+
+```bash
+chmod a+x set_aws_env.sh
+```
+
+Run the script:
+
+```bash
+./set_aws_env.sh <aws-profile e.g ons_sdp_dev_ecr> <environment  e.g sdp-dev> 
+```
+
+Verify the output is as expected:
+
+```bash
+Environment variables are set as:
+export AWS_ACCESS_KEY_ID=MYACCESSKEY
+export AWS_SECRET_ACCESS_KEY=MYSECRETACCESSKEY
+export AWS_DEFAULT_REGION=eu-west-2
+export APP_NAME=sdp-dev-copilot-usage
+```
+
+Ensure the script to build and push the image is executable:
+
+```bash
+chmod a+x publish_container.sh
+```
+
+Check the version of the image you want to build (verify the next available release by looking in ECR)
+
+Run the script, which will build an image locally, connect to ECR, push the image and then check the image is uploaded correctly.
+
+```bash
+./publish_container.sh <AWS Profile - e.g ons_sdp_dev_ecr> <AWS_ACCOUNT_NUMBER> <AWS Env - e.g sdp-dev> <image version - e.g v0.0.1>
+```
+
+### Manual Push to ECR
+
 These instructions assume:
 
 1. You have a repository set up in your AWS account named copilot-usage-dashboard.
@@ -172,7 +216,7 @@ You can find the AWS repo push commands under your repository in ECR by selectin
 
 When running the dashboard, you can toggle between using Live and Example Data.
 
-To use real data from the Github API, the project must be supplied with a copilot-usage-dashboard.pem file in AWS Secret Manager (as mentioned [here](./readme.md/#bootstrap-for-secrets-manager)). 
+To use real data from the Github API, the project must be supplied with a copilot-usage-dashboard.pem file in AWS Secret Manager (as mentioned [here](./readme.md/#bootstrap-for-secrets-manager)).
 
 This project also supports historic reporting outside of the 28 days which the API supplies. For more information on setup, please see this [README.md](../aws_lambda_scripts/README.md).
 
@@ -180,25 +224,26 @@ This project also supports historic reporting outside of the 28 days which the A
 
 This page shows CoPilot Usage at a team level.
 
-The user will be promted to login to GitHub on the page.
+The user will be prompted to login to GitHub on the page.
 
 Logged in users will only be able to see teams that they are a member of.
 
 If the logged in user is apart of an admin team, they can search for and view any team's metrics. See [Updating Admin Teams](#updating-admin-teams) for more information.
 
 **Please Note:**
-- The team must have a **minimum of 5 users with active copilot licenses** to have any data. 
+
+- The team must have a **minimum of 5 users with active copilot licenses** to have any data.
 - The team must be in the organisation the tool is running in.
 
 ### Updating Admin Teams
 
-Currently, there are 2 admin teams `keh-dev` and `sdp-dev`. 
+Currently, there are 2 admin teams `keh-dev` and `sdp-dev`.
 
 These teams are defined in `admin_teams.json` in the `copilot-usage-dashboard` bucket.
 
 To add another admin team, simply add the team name to `admin_teams.json`.
 
-## Github App 
+## Github App
 
 ### Permissions
 
@@ -278,7 +323,7 @@ The service requires access to an associated Github App secret, this secret is c
 
 AWS Secret Manager must be set up with a secret:
 
-- /sdp/tools/copilot-uasge/copilot-usage-dashboard.pem
+- /sdp/tools/copilot-usage/copilot-usage-dashboard.pem
   - A plaintext secret, containing the contents of the .pem file created when a Github App was installed.
 
 #### Running the Terraform
@@ -362,33 +407,40 @@ Delete the service resources by running the following ensuring your reference th
   terraform destroy -var-file=env/dev/dev.tfvars
   ```
 
-  ## Linting and Formatting
+## Linting and Formatting
+
 To view all commands
+
 ```bash
 make all
 ```
 
 Linting tools must first be installed before they can be used
+
 ```bash
 make install-dev
 ```
 
 To clean residue files
+
 ```bash
 make clean
 ```
 
 To format your code
+
 ```bash
 make format
 ```
 
 To run all linting tools
+
 ```bash
 make lint
 ```
 
 To run a specific linter (black, ruff, pylint)
+
 ```bash
 make black
 make ruff
@@ -396,11 +448,13 @@ make pylint
 ```
 
 To run mypy (static type checking)
+
 ```bash
 make mypy
 ```
 
 To run the application locally
+
 ```bash
 make run-local
 ```

--- a/publish_container.sh
+++ b/publish_container.sh
@@ -55,6 +55,16 @@ if [ "$4" ]; then
   if [ $? -ne 0 ]; then
     echo "Usage: $0 container-ver must be a valid version number e.g v1.0.0 or v1.0.0-alpha or v1.0.0-rc1"
     exit 1
+  else
+    # Check if the version already exists in the repository
+    IMAGE_EXISTS=$(aws ecr describe-images --profile $PROFILE --region "eu-west-2" --repository-name "$ENV-$IMAGE_NAME" --query "imageDetails[?contains(imageTags, '$VER')]" --output text)
+    if [ -n "$IMAGE_EXISTS" ]; then
+      echo "Docker image with tag $VER already exists in repository $ENV-$IMAGE_NAME. Rename, remove or use a different version number"
+      exit 1
+    else:
+      # Reset the IMAGE_EXISTS variable
+      IMAGE_EXISTS=""
+    fi
   fi
 fi
 
@@ -91,7 +101,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-IMAGE_EXISTS=$(aws ecr describe-images --profile $PROFILE --repository-name "$ENV-$IMAGE_NAME" --query "imageDetails[?contains(imageTags, '$VER')]" --output text)
+IMAGE_EXISTS=$(aws ecr describe-images --profile $PROFILE --region "eu-west-2" --repository-name "$ENV-$IMAGE_NAME" --query "imageDetails[?contains(imageTags, '$VER')]" --output text)
 
 if [ -n "$IMAGE_EXISTS" ]; then
   echo "Success - Docker image with tag $VER exists in repository $ENV-$IMAGE_NAME"

--- a/publish_container.sh
+++ b/publish_container.sh
@@ -1,0 +1,101 @@
+# aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin 381492126214.dkr.ecr.eu-west-2.amazonaws.com
+
+# docker build -t sdp-dev-copilot-usage .
+
+# docker tag sdp-dev-copilot-usage:latest 381492126214.dkr.ecr.eu-west-2.amazonaws.com/sdp-dev-copilot-usage:latest
+
+# docker push 381492126214.dkr.ecr.eu-west-2.amazonaws.com/sdp-dev-copilot-usage:latest
+
+#!/bin/bash
+
+# Function to validate the semantic versioning format
+# Example formats that are allowed are:
+# v1.0.0
+# v1.0.0-alpha
+# v1.0.0-rc1
+validate_semver() {
+    local version=$1
+
+    # Regular expression for semantic versioning (supports optional pre-release)
+    semver_regex="^v([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z-]+)?$"
+
+    if [[ $version =~ $semver_regex ]]; then
+        echo "Valid semantic version: $version"
+        return 0
+    else
+        echo "Invalid version format: $version"
+        return 1
+    fi
+}
+
+# Check if a profile name is passed as an argument
+if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ] ; then
+  echo "Usage: $0 <aws profile e.g ons_sdp_sandbox> <AWS account ID e.g 123456789> <env e.g sdp-sandbox> <container-ver e.g 1.0.0>"
+  exit 1
+fi
+
+PROFILE=$1
+ACCOUNT=$2
+ENV=$3
+VER=$4
+IMAGE_NAME=copilot-usage
+
+# Check if the environment matches expected values
+if [ "$3" != "sdp-sandbox" ] && [ "$3" != "sdp-dev" ] && [ "$3" != "sdp-prod" ]; then
+  echo "Usage: $0 env must be one of sdp-sandbox or sdp-dev or sdp-prod"
+  exit 1
+else
+    ENV=$3
+fi
+
+# Check if the version number is passed as an argument
+if [ "$4" ]; then
+  # Check it meets semver format
+  validate_semver $VER
+  if [ $? -ne 0 ]; then
+    echo "Usage: $0 container-ver must be a valid version number e.g v1.0.0 or v1.0.0-alpha or v1.0.0-rc1"
+    exit 1
+  fi
+fi
+
+aws ecr get-login-password --profile $PROFILE --region eu-west-2 | docker login --username AWS --password-stdin $ACCOUNT.dkr.ecr.eu-west-2.amazonaws.com
+
+echo "Building Docker image: $IMAGE_NAME with tag: $VER"
+docker build -t $IMAGE_NAME:$VER .
+
+# Check if the Docker build command was successful
+if [ $? -ne 0 ]; then
+  echo "Docker build failed"
+  exit 1
+fi
+
+# Wait for the build to finish
+echo "Docker build completed. Verifying the image exists..."
+
+# Run docker images to check if the image exists
+if docker images | grep -q "$IMAGE_NAME.*$VER"; then
+  echo "Docker image $IMAGE_NAME:$VER exists"
+else
+  echo "Docker image $IMAGE_NAME:$VER not found"
+  exit 1
+fi
+
+echo "Tagging Docker image: $IMAGE_NAME with tag: $VER"
+docker tag $IMAGE_NAME:$VER $ACCOUNT.dkr.ecr.eu-west-2.amazonaws.com/$ENV-$IMAGE_NAME:$VER
+
+echo "Pushing Docker image: $IMAGE_NAME with tag: $VER to ECR"
+docker push $ACCOUNT.dkr.ecr.eu-west-2.amazonaws.com/$ENV-$IMAGE_NAME:$VER
+
+if [ $? -ne 0 ]; then
+  echo "Docker push failed"
+  exit 1
+fi
+
+IMAGE_EXISTS=$(aws ecr describe-images --profile $PROFILE --repository-name "$ENV-$IMAGE_NAME" --query "imageDetails[?contains(imageTags, '$VER')]" --output text)
+
+if [ -n "$IMAGE_EXISTS" ]; then
+  echo "Success - Docker image with tag $VER exists in repository $ENV-$IMAGE_NAME"
+else
+  echo "Failure - Docker image with tag $VER does not exist in repository $ENV-$IMAGE_NAME"
+  exit 1
+fi

--- a/set_aws_env.sh
+++ b/set_aws_env.sh
@@ -1,0 +1,79 @@
+#! /bin/sh
+
+# The script expects the aws credentials file to be located at ~/.aws/credentials
+# The credentials file should have the following format, [proflie-name]:
+# personal aws account
+# [default]
+# aws_access_key_id = EXAMPLEACCESSKEY
+# aws_secret_access_key = EXAMPLESECRETACCESSKEY
+# [ecr_account]
+# aws_access_key_id = EXAMPLEACCESSKEY-ECR
+# aws_secret_access_key = EXAMPLESECRETACCESSKEY-ECR
+# # organisation aws account
+# [ons_sdp_sandbox]
+# aws_access_key_id = EXAMPLEACCESSKEY-SANDBOX
+# aws_secret_access_key = EXAMPLESECRETACCESSKEY-SANDBOX
+
+
+#!/bin/bash
+
+# Check if a profile name is passed as an argument
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 <profile-name e.g ons_sdp_sandbox> <env e.g sdp-sandbox>"
+  exit 1
+fi
+
+PROFILE=$1
+CREDENTIALS_FILE="$HOME/.aws/credentials"
+
+# Check if the environment matches expected values
+if [ "$2" != "sdp-sandbox" ] && [ "$2" != "sdp-dev" ]; then
+  echo "Usage: $0 env must be one of sdp-sandbox or sdp-dev"
+  exit 1
+else
+    ENV=$2
+fi
+
+# Check if the credentials file exists
+if [ ! -f "$CREDENTIALS_FILE" ]; then
+  echo "Credentials file not found: $CREDENTIALS_FILE"
+  echo "Set one up by installing aws cli and running: aws configure"
+  exit 1
+fi
+
+# Read the credentials file and set environment variables based on the profile
+while IFS= read -r line; do
+  # Skip empty lines and comments
+  if [[ -z "$line" || "$line" =~ ^# ]]; then
+    continue
+  fi
+
+  # Check if the line is a profile header
+  if [[ "$line" =~ ^\[(.*)\]$ ]]; then
+    CURRENT_PROFILE="${BASH_REMATCH[1]}"
+  fi
+
+  # If the current profile matches the specified profile, set the variables
+  if [[ "$CURRENT_PROFILE" == "$PROFILE" ]]; then
+    if [[ "$line" =~ aws_access_key_id[[:space:]]*=[[:space:]]*(.*) ]]; then
+      export AWS_ACCESS_KEY_ID="${BASH_REMATCH[1]}"
+    elif [[ "$line" =~ aws_secret_access_key[[:space:]]*=[[:space:]]*(.*) ]]; then
+      export AWS_SECRET_ACCESS_KEY="${BASH_REMATCH[1]}"
+    fi
+  fi
+done < "$CREDENTIALS_FILE"
+
+# Check if the environment variables were set
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  echo "Failed to set environment variables for profile: $PROFILE"
+  exit 1
+fi
+
+export AWS_DEFAULT_REGION="eu-west-2"
+export APP_NAME=$ENV"-copilot-usage"
+
+echo "Environment variables are set as:"
+echo "export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+echo "export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+echo "export AWS_DEFAULT_REGION=eu-west-2"
+echo "export APP_NAME=$APP_NAME"


### PR DESCRIPTION
Added two scripts and updated the README.

**set_aws_env.sh** - When the user has an AWS credentials file at ~/.aws/credentials that is populated with multiple sets of credentials using the profile nomenclature below. Then this script can be used to set appropriate environment variables in the terminal by specifying profile and environment

```bash
[default]
aws_access_key_id = default_accesskey
aws_secret_access_key = default_secretkey
[account_ecr_user]
aws_access_key_id = account_ecr_user_accesskey
aws_secret_access_key = account_ecr_user_secretkey
...
```

**publish_container.sh** - When the user has a profile setup in their AWS credential file, this script can be used to build, login and publish an image to ECR. This script requires the user to specify the AWS profile, AWS account number, environment and version that you require the container to be tagged with (e.g v0.0.1).

**README.md** - Updated with above details.