### PR TITLE
Bug | Env Specific Terraform Backend

### DIFF
--- a/terraform/data_logger/env/dev/backend-dev.tfbackend
+++ b/terraform/data_logger/env/dev/backend-dev.tfbackend
@@ -3,4 +3,4 @@
 bucket         = "sdp-dev-tf-state"
 key            = "sdp-dev-ecs-copilot-usage-lambda/terraform.tfstate"
 region         = "eu-west-2"
-dynamodb_table = "terraform-state-lock"
+dynamodb_table = "sdp-dev-terraform-state-lock"

--- a/terraform/data_logger/env/dev/backend-dev.tfbackend
+++ b/terraform/data_logger/env/dev/backend-dev.tfbackend
@@ -3,4 +3,4 @@
 bucket         = "sdp-dev-tf-state"
 key            = "sdp-dev-ecs-copilot-usage-lambda/terraform.tfstate"
 region         = "eu-west-2"
-dynamodb_table = "sdp-dev-terraform-state-lock"
+dynamodb_table = "terraform-state-lock"

--- a/terraform/data_logger/env/prod/backend-prod.tfbackend
+++ b/terraform/data_logger/env/prod/backend-prod.tfbackend
@@ -3,4 +3,4 @@
 bucket         = "sdp-prod-tf-state"
 key            = "sdp-prod-ecs-copilot-usage-lambda/terraform.tfstate"
 region         = "eu-west-2"
-dynamodb_table = "terraform-state-lock"
+dynamodb_table = "sdp-prod-terraform-state-lock"


### PR DESCRIPTION
Before the change, `<env>-backend.tfbackend` references the dynamoDB Table `terraform-state-lock`. On prod and dev, this table does not exists and is replaced by `<env>-terraform-state-lock`. This PR changes the terraform .tfbackend files to match.