### PR TITLE
KEH-383 | Team Usage Dropdown

### DIFF
--- a/lambda_data_logger/README.md
+++ b/lambda_data_logger/README.md
@@ -3,6 +3,7 @@
 This script is used to gather data from the /orgs/{org}/copilot/usage endpoint in the Github API.
 The script then appends the collected data to the old data in an S3 bucket.
 This creates a record of historical copilot usage data which is used to show trends over time.
+The script also gets a list of GitHub Teams with CoPilot Usage Data. This is to reduce load times in the frontend.
 The API endpoint above only stores the last 28 days worth of data, meaning this script must run atleast every 28 days to avoid missing data.
 This script is run as a containered lambda function in AWS which is executed periodically using EventBridge.
 

--- a/src/pages/team_usage.py
+++ b/src/pages/team_usage.py
@@ -179,33 +179,6 @@ def get_user_teams(access_token, profile):
     team_names = [edge["node"]["name"] for edge in teams_data["data"]["organization"]["teams"]["edges"]]
     return team_names
 
-# TODO: Remove the below code when it is no longer needed. Dashboard should be able to offer this.
-
-# # Run to get the copilot teams that are available.
-# def get_copilot_teams(access_token):
-#     print("Running get_copilot_teams")
-#     gh = github_api_toolkit.github_interface(access_token[0])
-#     copilot_teams = []
-
-#     for x in [1, 2]:
-#         print(x)
-#         teams = gh.get(f"/orgs/{org}/teams", params={"per_page": 100, "page": x})
-#         teams = teams.json()
-#         for team in teams:
-#             usage_data = gh.get(f"/orgs/{org}/team/{team['name']}/copilot/usage")
-#             try:
-#                 if usage_data.json() != []:
-#                     copilot_teams.append(team['name'])
-#                     print(copilot_teams)
-#             except Exception as error:
-#                 print(error)
-
-#     if copilot_teams:
-#         date_str = datetime.now().strftime("%Y-%m-%d")
-#         file_path = f"./src/example_data/copilot_teams_{date_str}.json"
-#         with open(file_path, "a") as file:
-#             json.dump(copilot_teams, file)
-
 
 @st.cache_data
 def get_org_copilot_teams(run_day: int) -> list:

--- a/src/pages/team_usage.py
+++ b/src/pages/team_usage.py
@@ -207,6 +207,27 @@ def get_user_teams(access_token, profile):
 #             json.dump(copilot_teams, file)
 
 
+@st.cache_data
+def get_org_copilot_teams(run_day: int) -> list:
+    """Retrieves a list of GitHub Teams which have GitHub Copilot usage data from AWS S3.
+
+    Args:
+        run_day (int): The day the function was run. This is used to cache the data for a day.
+
+    Returns:
+        list: A list of team names that have GitHub Copilot usage data.
+    """
+    
+    try:
+        response = s3.get_object(Bucket=bucket_name, Key="copilot_teams.json")
+        copilot_teams = json.loads(response["Body"].read().decode("utf-8"))
+    except ClientError as e:
+        st.error("An error occurred while trying to get the copilot_teams.json from S3. Please check the error message below.")
+        st.error(e)
+        st.stop()
+
+    return copilot_teams
+
 def get_team_seats(team):
     """Retrieves and filters GitHub Copilot seat data for a specific team within an organization.
 
@@ -308,6 +329,8 @@ if st.session_state.profile:
     # Get the users teams
     user_teams = get_user_teams(access_token[0], st.session_state.profile)
 
+    org_teams = get_org_copilot_teams(datetime.now().day)
+
     if access_token and user_teams:
         # Get admin_teams.json from S3
         try:
@@ -332,10 +355,12 @@ if st.session_state.profile:
             if input_method == "Select your team":
                 team_slug = st.selectbox("Select team:", options=user_teams)
             else:
-                team_slug = st.text_input("Enter team name:", value=user_teams[0] if user_teams else "")
+                team_slug = st.selectbox("Enter team name:", options=org_teams)
 
         else:
             team_slug = st.selectbox("Select team:", options=user_teams)
+
+        st.html("<b>Please Note:</b> You can type within the input to search for a team.")
 
         if team_slug and isinstance(access_token, tuple):
             if team_slug not in st.session_state:


### PR DESCRIPTION
Changes involve replacing the search bar with a populated dropdown of teams with data from S3.

**Dashboard Changes:**
- UI is now a selectbox instead of textbox.
- Method to get teams from S3.
- The Method is cached so that it only updates once per day.

**Lambda Changes:**
- Lambda now collects a list of teams with CoPilot Usage Data from the GitHub API.
- This list is stored in S3 as `copilot_teams.json`.
- The functionality was moved to the Lambda to reduce wait times in the frontend (200 teams in GH -> 200 API Calls).