### PR TITLE
KEH-1155 - Record more in copilot_teams.json

### DIFF
--- a/lambda_data_logger/main.py
+++ b/lambda_data_logger/main.py
@@ -65,7 +65,14 @@ def get_copilot_team_date(gh: github_api_toolkit.github_interface, page: int) ->
         usage_data = gh.get(f"/orgs/{org}/team/{team['name']}/copilot/metrics")
         try:
             if usage_data.json():
-                copilot_teams.append(team["name"])
+                copilot_teams.append(
+                    {
+                        "name": team["name"],
+                        "slug": team["slug"],
+                        "description": team["description"],
+                        "url": team["html_url"],
+                    }
+                )
         except Exception as error:
             # If Exception, then the team does not have copilot usage data and can be skipped
             pass

--- a/lambda_data_logger/main.py
+++ b/lambda_data_logger/main.py
@@ -67,10 +67,10 @@ def get_copilot_team_date(gh: github_api_toolkit.github_interface, page: int) ->
             if usage_data.json():
                 copilot_teams.append(
                     {
-                        "name": team["name"],
-                        "slug": team["slug"],
-                        "description": team["description"],
-                        "url": team["html_url"],
+                        "name": team.get("name", ""),
+                        "slug": team.get("slug", ""),
+                        "description": team.get("description", ""),
+                        "url": team.get("html_url", ""),
                     }
                 )
         except Exception as error:

--- a/terraform/dashboard/providers.tf
+++ b/terraform/dashboard/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 6.2.0"
     }
   }
 }

--- a/terraform/data_logger/providers.tf
+++ b/terraform/data_logger/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 6.2.0"
     }
   }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

### What

Changed how the copilot_teams is recorded. On the digital landscape, for the KEH-1122 when a user is in an admin team, we then fetch the copilot_teams.json as this is a list of valid teams (5< active copilot licenses) and then we display those on the frontend. This was just a list before and so it didn't have the description of the team, meaning we'd have to make a request for each team to get its info (theres 10+ valid teams currently) so it the requests get a bit much.

FROM:

```json
["test"]
```

TO:

```json
[
    {
        "name": "test",
        "slug": "test",
        "description": "Used by https://github.com/ONSdigital/test",
        "url": "https://github.com/orgs/ONSdigital/teams/test"
    },
    { ... }
]
```
   

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

No. No mention of copilot_teams in the `docs` (mkdocs) folder.

### How to review

Follow steps in `/lambda_data_logger/README.md`