### PR TITLE
KEH-1795 | Increase Lambda Memory

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -46,6 +46,8 @@ resource "aws_lambda_function" "lambda_function" {
 
   role = aws_iam_role.lambda_function_role.arn
 
+  memory_size = 256
+
   environment {
     variables = {
       ENVIRONMENT          = var.env_name


### PR DESCRIPTION
# What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## What

The lambda has been failing to run on AWS due to running out of memory.
As a temporary fix, I have increased from 128MB to 256MB. This works fine.

As an aside in this PR, I will look to improve its memory usage and make it more efficient (TODO in another PR).

## Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [ ] No
      Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

## Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [ ] No
      Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

## Related issues

KEH-1795 (Jira)

## How to review

Describe the steps required to test the changes.
